### PR TITLE
Allow passing a screen to PrimeUI.clear() for use on a monitor

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -12,7 +12,7 @@ Aspernatur in animi sint perspiciatis aliquam iste vero quas. Cumque beatae vel 
 
 local PrimeUI = require "init"
 
-PrimeUI.clear()
+PrimeUI.clear(term.current())
 PrimeUI.label(term.current(), 3, 2, "Sample Text")
 PrimeUI.horizontalLine(term.current(), 3, 3, #("Sample Text") + 2)
 PrimeUI.borderBox(term.current(), 4, 6, 40, 10)

--- a/util.lua
+++ b/util.lua
@@ -26,13 +26,13 @@ do
 
     --- Clears the screen and resets all components. Do not use any previously
     --- created components after calling this function.
-    function PrimeUI.clear()
+    function PrimeUI.clear(screen)
         -- Reset the screen.
-        term.setCursorPos(1, 1)
-        term.setCursorBlink(false)
-        term.setBackgroundColor(colors.black)
-        term.setTextColor(colors.white)
-        term.clear()
+        screen.setCursorPos(1, 1)
+        screen.setCursorBlink(false)
+        screen.setBackgroundColor(colors.black)
+        screen.setTextColor(colors.white)
+        screen.clear()
         -- Reset the task list and cursor restore function.
         coros = {}
         restoreCursor = nil


### PR DESCRIPTION
This change allows PrimeUI to clear the screen and coros on another screen (like a monitor)