### PR TITLE
Fix click and scroll for moving elements

### DIFF
--- a/PrimeUI.d.ts
+++ b/PrimeUI.d.ts
@@ -44,13 +44,16 @@ declare namespace PrimeUI {
     function setCursorWindow(win: Window | null | undefined): void;
 
     /**
-     * Gets the absolute position of a coordinate relative to a window.
-     * @param win The window to check
-     * @param x The relative X position of the point
-     * @param y The relative Y position of the point
-     * @return The absolute X and Y position of the window
+     * Returns the position of a point given in absolute coordinates relative to the specified window,
+     * or nil if this point is outside the window.
+     * Particularly useful when getting data from events.
+     * @param win window The window to check
+     * @param absx number The absolute X position of the point
+     * @param absy number The absolute Y position of the point
+     * @return number|nil x The X position of the point relative to the window, or nil if outside the window
+     * @return number|nil y The Y position of the point relative to the window, or nil if oustide the window
      */
-    function getWindowPos(win: ITerminal, x: number, y: number): LuaMultiReturn<[number, number]>;
+    function getPosInWindow(win: ITerminal, absx: number, absy: number): LuaMultiReturn<[number, number]>;
 
     /**
      * Runs the main loop, returning information on an action.

--- a/button.lua
+++ b/button.lua
@@ -28,13 +28,14 @@ function PrimeUI.button(win, x, y, text, action, fgColor, bgColor, clickedColor,
     win.setBackgroundColor(bgColor)
     win.setTextColor(fgColor)
     win.write(" " .. text .. " ")
-    -- Get the screen position and add a click handler.
+    -- Add a click handler.
     PrimeUI.addTask(function()
-        local screenX, screenY = PrimeUI.getWindowPos(win, x, y)
         local buttonDown = false
         while true do
             local event, button, clickX, clickY = os.pullEvent()
-            if event == "mouse_click" and periphName == nil and button == 1 and clickX >= screenX and clickX < screenX + #text + 2 and clickY == screenY then
+            -- Get the position of the click in the window
+            local winx, winy = PrimeUI.getPosInWindow(win, clickX, clickY)
+            if event == "mouse_click" and periphName == nil and button == 1 and winx and winx >= x and winx < x + #text + 2 and winy == y then
                 -- Initiate a click action (but don't trigger until mouse up).
                 buttonDown = true
                 -- Redraw the button with the clicked background color.
@@ -42,10 +43,10 @@ function PrimeUI.button(win, x, y, text, action, fgColor, bgColor, clickedColor,
                 win.setBackgroundColor(clickedColor)
                 win.setTextColor(fgColor)
                 win.write(" " .. text .. " ")
-            elseif (event == "monitor_touch" and periphName == button and clickX >= screenX and clickX < screenX + #text + 2 and clickY == screenY)
+            elseif (event == "monitor_touch" and periphName == button and winx and winx >= x and winx < x + #text + 2 and winy == y)
                 or (event == "mouse_up" and button == 1 and buttonDown) then
                 -- Finish a click event.
-                if clickX >= screenX and clickX < screenX + #text + 2 and clickY == screenY then
+                if winx >= x and winy < x + #text + 2 and winy == y then
                     -- Trigger the action.
                     if type(action) == "string" then
                         PrimeUI.resolve("button", action)

--- a/checkSelectionBox.lua
+++ b/checkSelectionBox.lua
@@ -54,8 +54,7 @@ function PrimeUI.checkSelectionBox(win, x, y, width, height, selections, action,
     inner.setCursorPos(2, selected)
     inner.setCursorBlink(true)
     PrimeUI.setCursorWindow(inner)
-    -- Get screen coordinates & add run task.
-    local screenX, screenY = PrimeUI.getWindowPos(win, x, y)
+    -- Run task.
     PrimeUI.addTask(function()
         local scrollPos = 1
         while true do
@@ -83,8 +82,12 @@ function PrimeUI.checkSelectionBox(win, x, y, width, height, selections, action,
                     end
                     inner.setCursorPos(2, selected)
                 end
-            elseif ev[1] == "mouse_scroll" and ev[3] >= screenX and ev[3] < screenX + width and ev[4] >= screenY and ev[4] < screenY + height then
-                dir = ev[2]
+            elseif ev[1] == "mouse_scroll" then
+                --- Check if the coordinates are in the scrollable window
+                local winx, winy = PrimeUI.getPosInWindow(outer, ev[3], ev[4])
+                if winx then
+                    dir = ev[2]
+                end
             end
             -- Scroll the screen if required.
             if dir and (selected + dir >= 1 and selected + dir <= nsel) then

--- a/clickRegion.lua
+++ b/clickRegion.lua
@@ -19,16 +19,14 @@ function PrimeUI.clickRegion(win, x, y, width, height, action, periphName)
     expect(6, action, "function", "string")
     expect(7, periphName, "string", "nil")
     PrimeUI.addTask(function()
-        -- Get the screen position and add a click handler.
-        local screenX, screenY = PrimeUI.getWindowPos(win, x, y)
-        local buttonDown = false
         while true do
             local event, button, clickX, clickY = os.pullEvent()
             if (event == "monitor_touch" and periphName == button)
                 or (event == "mouse_click" and button == 1 and periphName == nil) then
-                -- Finish a click event.
-                if clickX >= screenX and clickX < screenX + width
-                    and clickY >= screenY and clickY < screenY + height then
+                -- Get the position of the click in the window and finish the click event
+                local winx, winy = PrimeUI.getPosInWindow(win, clickX, clickY)
+                if winx and x <= winx and y <= winy and winx <= x + width - 1
+                    and winy <= y + height - 1 then
                     -- Trigger the action.
                     if type(action) == "string" then
                         PrimeUI.resolve("clickRegion", action)

--- a/init.lua
+++ b/init.lua
@@ -16,4 +16,5 @@ require "scrollBox"
 require "selectionBox"
 require "textBox"
 require "timeout"
+require "clickRegion"
 return PrimeUI

--- a/scrollBox.lua
+++ b/scrollBox.lua
@@ -41,8 +41,6 @@ function PrimeUI.scrollBox(win, x, y, width, height, innerHeight, allowArrowKeys
         outer.setCursorPos(width, height)
         outer.write(innerHeight > height and "\31" or " ")
     end
-    -- Get the absolute position of the window.
-    x, y = PrimeUI.getWindowPos(win, x, y)
     -- Add the scroll handler.
     PrimeUI.addTask(function()
         local scrollPos = 1
@@ -56,8 +54,12 @@ function PrimeUI.scrollBox(win, x, y, width, height, innerHeight, allowArrowKeys
             if ev[1] == "key" and allowArrowKeys then
                 if ev[2] == keys.up then dir = -1
                 elseif ev[2] == keys.down then dir = 1 end
-            elseif ev[1] == "mouse_scroll" and ev[3] >= x and ev[3] < x + width and ev[4] >= y and ev[4] < y + height then
-                dir = ev[2]
+            elseif ev[1] == "mouse_scroll" then
+                --- Get the relative position of the event in the window
+                local winx, winy = PrimeUI.getPosInWindow(outer, ev[3], ev[4])
+                if winx then
+                    dir = ev[2]
+                end
             end
             -- If there's a scroll event, move the window vertically.
             if dir and (scrollPos + dir >= 1 and scrollPos + dir <= innerHeight - height) then

--- a/util.lua
+++ b/util.lua
@@ -45,21 +45,36 @@ do
         restoreCursor = win and win.restoreCursor
     end
 
-    --- Gets the absolute position of a coordinate relative to a window.
-    ---@param win window The window to check
-    ---@param x number The relative X position of the point
-    ---@param y number The relative Y position of the point
-    ---@return number x The absolute X position of the window
-    ---@return number y The absolute Y position of the window
-    function PrimeUI.getWindowPos(win, x, y)
-        if win == term then return x, y end
+    --- Returns the position of a point given in absolute coordinates relative to the specified window,
+    --- or nil if this point is outside the window.
+    --- Particularly useful when getting data from events.
+    --- @param win window The window to check
+    --- @param absx number The absolute X position of the point
+    --- @param absy number The absolute Y position of the point
+    --- @return number|nil x The X position of the point relative to the window, or nil if outside the window
+    --- @return number|nil y The Y position of the point relative to the window, or nil if oustide the window
+    function PrimeUI.getPosInWindow(win, absx, absy)
+        if win == term then return end
+        local wins = {}
+        -- local x, y = 1, 1
         while win ~= term.native() and win ~= term.current() do
-            if not win.getPosition then return x, y end
-            local wx, wy = win.getPosition()
-            x, y = x + wx - 1, y + wy - 1
+            table.insert(wins, win)
+            if not win.getPosition then break end
+            -- local wx, wy = win.getPosition()
+            -- local ww, wh = win.getSize()
+            -- x, y = x + wx - 1, y + wy - 1
             _, win = debug.getupvalue(select(2, debug.getupvalue(win.isColor, 1)), 1) -- gets the parent window through an upvalue
         end
-        return x, y
+        for i=#wins, 1, -1 do
+          win = wins[i]
+          local wx, wy = win.getPosition()
+          local ww, wh = win.getSize()
+          absx, absy = absx - wx + 1, absy - wy + 1
+          if absx < 1 or absy < 1 or absx >= ww + 1 or absy >= wh + 1 then
+              return nil
+          end
+        end
+        return absx, absy
     end
 
     --- Runs the main loop, returning information on an action.


### PR DESCRIPTION
When clickable elements are movable (for example when in a scrollbox), their "hitbox" don't move when the element move.
Moreover, when the origin of the element is out of the screen, it becomes impossible to click them.

Here is a minimal demo of the issue:

```lua
local PrimeUI = require("init")

PrimeUI.clear()

local function draw_box(display,x,y,w,h,color)
    local color    = ("%x"):format(math.log(color,2))
    local line_str = color:rep(w)

    for line_y=y,y+h - 1 do
        display.setCursorPos(x,line_y)
        display.blit(line_str,line_str,line_str)
    end
end

local win = term.current()

local w, h = win.getSize()

local scroll = PrimeUI.scrollBox(win, 1, math.floor(h/2), w, math.floor(h/2-1), h, true)

PrimeUI.clickRegion(scroll, 1, 1, w, math.floor(h/2), function ()
  draw_box(scroll, 1, 1, w, math.floor(h/2), colors.gray)
  sleep(0.5)
  draw_box(scroll, 1, 1, w, math.floor(h/2), colors.lightGray)
end)

draw_box(scroll, 1, 1, w, math.floor(h/2), colors.lightGray)

PrimeUI.run()
```

This is opinionated, it increases the size of `util.lua` and idk if you will like it the way I did it.

I also fixed a minor issue in `init.lua`.

Documentation is missing, this is why this PR is marked as draft.